### PR TITLE
Azerbaijan IBAN contains letters

### DIFF
--- a/src/IBANTools.ts
+++ b/src/IBANTools.ts
@@ -418,7 +418,7 @@ const countrySpecs: CountryMap = {
   },
   AZ: {
     chars: 28,
-    bban_regexp: "^[A-Z]{4}[0-9]{20}$",
+    bban_regexp: "^[A-Z]{4}[A-Z0-9]{20}$",
     IBANRegistry: true,
     SEPA: false
   },


### PR DESCRIPTION
Based on account numbers of "UNiBANK Commercial Bank Open Joint-Stock Company" (BIC: UBAZAZ22)

Fixes false negatives of AZ… IBANs