### PR TITLE
Fix IBAN validation for BF, BJ, DZ and ML

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-03-29 Xavier Alvarez
+	* Fix validation for Burkina Faso, Benin, Algeria and Mali
+
 2021-03-10  Saša Jovanić  <sasa@simplify.ba>
 	* Version 3.2.4
 	* Exported `countrySpecs` to restore a bit of compatibility broken in 3.2.3

--- a/dist/ibantools.js
+++ b/dist/ibantools.js
@@ -382,8 +382,8 @@ define(["require", "exports"], function (require, exports) {
         BD: {},
         BE: { chars: 16, bban_regexp: '^[0-9]{12}$', IBANRegistry: true, SEPA: true },
         BF: {
-            chars: 27,
-            bban_regexp: '^[0-9]{23}$',
+            chars: 28,
+            bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
         },
         BG: {
             chars: 22,
@@ -401,7 +401,7 @@ define(["require", "exports"], function (require, exports) {
         },
         BJ: {
             chars: 28,
-            bban_regexp: '^[A-Z]{1}[0-9]{23}$',
+            bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
         },
         BL: {
             chars: 27,
@@ -485,8 +485,8 @@ define(["require", "exports"], function (require, exports) {
             IBANRegistry: true,
         },
         DZ: {
-            chars: 24,
-            bban_regexp: '^[0-9]{20}$',
+            chars: 26,
+            bban_regexp: '^[0-9]{22}$',
         },
         EC: {},
         EE: { chars: 20, bban_regexp: '^[0-9]{16}$', IBANRegistry: true, SEPA: true },
@@ -710,7 +710,7 @@ define(["require", "exports"], function (require, exports) {
         },
         ML: {
             chars: 28,
-            bban_regexp: '^[A-Z]{1}[0-9]{23}$',
+            bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
         },
         MM: {},
         MN: {},

--- a/src/IBANTools.ts
+++ b/src/IBANTools.ts
@@ -450,8 +450,8 @@ export const countrySpecs: CountryMapInternal = {
   BD: {},
   BE: { chars: 16, bban_regexp: '^[0-9]{12}$', IBANRegistry: true, SEPA: true },
   BF: {
-    chars: 27,
-    bban_regexp: '^[0-9]{23}$',
+    chars: 28,
+    bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
   },
   BG: {
     chars: 22,
@@ -469,7 +469,7 @@ export const countrySpecs: CountryMapInternal = {
   },
   BJ: {
     chars: 28,
-    bban_regexp: '^[A-Z]{1}[0-9]{23}$',
+    bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
   },
   BL: {
     chars: 27,
@@ -553,8 +553,8 @@ export const countrySpecs: CountryMapInternal = {
     IBANRegistry: true,
   },
   DZ: {
-    chars: 24,
-    bban_regexp: '^[0-9]{20}$',
+    chars: 26,
+    bban_regexp: '^[0-9]{22}$',
   },
   EC: {},
   EE: { chars: 20, bban_regexp: '^[0-9]{16}$', IBANRegistry: true, SEPA: true },
@@ -778,7 +778,7 @@ export const countrySpecs: CountryMapInternal = {
   },
   ML: {
     chars: 28,
-    bban_regexp: '^[A-Z]{1}[0-9]{23}$',
+    bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
   },
   MM: {},
   MN: {},

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -99,7 +99,7 @@ describe('IBANTools', function() {
       expect(iban.isValidIBAN('EG380019000500000000263180002')).to.be.true;
     });
     it('with valid Algeria IBAN should return true', function() {
-      expect(iban.isValidIBAN('DZ3512341234123412341234')).to.be.true;
+      expect(iban.isValidIBAN('DZ580002100001113000000570')).to.be.true;
     });
     it('with valid Angola IBAN should return true', function() {
       expect(iban.isValidIBAN('AO44123412341234123412341')).to.be.true;
@@ -108,7 +108,7 @@ describe('IBANTools', function() {
       expect(iban.isValidIBAN('BJ83A12312341234123412341234')).to.be.true;
     });
     it('with valid Burkina Faso IBAN should return true', function() {
-      expect(iban.isValidIBAN('BF4512341234123412341234123')).to.be.true;
+      expect(iban.isValidIBAN('BF42BF0840101300463574000390')).to.be.true;
     });
     it('with valid Burundi IBAN should return true', function() {
       expect(iban.isValidIBAN('BI33123412341234')).to.be.true;


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix IBAN validation for Burkina Faso, Benin, Algeria and Mali according to the formulas described [here](https://en.wikipedia.org/wiki/International_Bank_Account_Number).

### Tests (check `[x]` one of those)

- [ ] I have added test(s)
- [x] My change does not need new tests

### ChangeLog

- [x] I have added entry in `ChangeLog` file (if not, please do so)
