### PR TITLE
fix/unknown-country-validation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-05 Daniel Friesen <d@danf.ca>
+  * Fixed `validateIBAN`'s handling of unsupported countries like US
+  * Added checksum validation for unsupported/unknown countries to `validateIBAN`
+
 2021-04-03  Saša Jovanić <sasa@simplify.ba>
 	* Coverage improved to 100%
 

--- a/src/IBANTools.ts
+++ b/src/IBANTools.ts
@@ -77,27 +77,26 @@ export function validateIBAN(iban?: string): ValidateIBANResult {
   const result = { errorCodes: [], valid: true } as ValidateIBANResult;
   if (iban !== undefined && iban !== null && iban !== '') {
     const spec = countrySpecs[iban.slice(0, 2)];
-    if (spec === undefined) {
+    if (!spec || !(spec.bban_regexp || spec.chars)) {
       result.valid = false;
       result.errorCodes.push(ValidationErrorsIBAN.NoIBANCountry);
-    } else {
-      if (spec.chars !== iban.length) {
-        result.valid = false;
-        result.errorCodes.push(ValidationErrorsIBAN.WrongBBANLength);
-      }
-      if (spec.bban_regexp && !checkFormatBBAN(iban.slice(4), spec.bban_regexp)) {
-        result.valid = false;
-        result.errorCodes.push(ValidationErrorsIBAN.WrongBBANFormat);
-      }
-      const reg = new RegExp('^[0-9]{2}$', '');
-      if (!reg.test(iban.slice(2, 4))) {
-        result.valid = false;
-        result.errorCodes.push(ValidationErrorsIBAN.ChecksumNotNumber);
-      }
-      if (!isValidIBANChecksum(iban)) {
-        result.valid = false;
-        result.errorCodes.push(ValidationErrorsIBAN.WrongIBANChecksum);
-      }
+    }
+    if (spec && spec.chars && spec.chars !== iban.length) {
+      result.valid = false;
+      result.errorCodes.push(ValidationErrorsIBAN.WrongBBANLength);
+    }
+    if (spec && spec.bban_regexp && !checkFormatBBAN(iban.slice(4), spec.bban_regexp)) {
+      result.valid = false;
+      result.errorCodes.push(ValidationErrorsIBAN.WrongBBANFormat);
+    }
+    const reg = new RegExp('^[0-9]{2}$', '');
+    if (!reg.test(iban.slice(2, 4))) {
+      result.valid = false;
+      result.errorCodes.push(ValidationErrorsIBAN.ChecksumNotNumber);
+    }
+    if (!isValidIBANChecksum(iban)) {
+      result.valid = false;
+      result.errorCodes.push(ValidationErrorsIBAN.WrongIBANChecksum);
     }
   } else {
     result.valid = false;

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -216,10 +216,31 @@ describe('IBANTools', function() {
       });
     });
 
-    it('with invalid IBAN country should return false with correct code', function() {
-      expect(iban.validateIBAN('XX91ABNA0517164300')).to.deep.equal({
+    it('with invalid IBAN country and correct checksum should return false with correct code', function() {
+      expect(iban.validateIBAN('XX09ABNA0517164300')).to.deep.equal({
         valid: false,
         errorCodes: [iban.ValidationErrorsIBAN.NoIBANCountry],
+      });
+    });
+
+    it('with invalid IBAN country and wrong checksum should return false with wrong code', function() {
+      expect(iban.validateIBAN('XX91ABNA0517164300')).to.deep.equal({
+        valid: false,
+        errorCodes: [iban.ValidationErrorsIBAN.NoIBANCountry, iban.ValidationErrorsIBAN.WrongIBANChecksum],
+      });
+    });
+
+    it('with country with no IBAN support should return false with correct code', function() {
+      expect(iban.validateIBAN('US64SVBKUS6S3300958879')).to.deep.equal({
+        valid: false,
+        errorCodes: [iban.ValidationErrorsIBAN.NoIBANCountry],
+      });
+    });
+
+    it('with country with no IBAN support and wrong checksum should return false with wrong code', function() {
+      expect(iban.validateIBAN('US46SVBKUS6S3300958879')).to.deep.equal({
+        valid: false,
+        errorCodes: [iban.ValidationErrorsIBAN.NoIBANCountry, iban.ValidationErrorsIBAN.WrongIBANChecksum],
       });
     });
 


### PR DESCRIPTION
Fixes #50

Changes proposed in this pull request:
- Fixes validateIBAN so unsupported countries like US are treated the same as unknown countries like XX (just like isValidIBAN)
- Validate the checksum for unsupported/unknown countries

### Tests (check `[x]` one of those)

- [x] I have added test(s)
- [ ] My change does not need new tests

### ChangeLog

- [x] I have added entry in `ChangeLog` file (if not, please do so)
