### PR TITLE
add MOD11 check to norwegian BBANS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -210,3 +210,6 @@
 	* Added this ChangeLog
 	* Updated development dependencies and typings
 	* Removed old script that used to retrive IBAN countries and codes from Wikipedia
+
+2021-09-30 Simen Mailund Svendsen <simen.m.s@hotmail.com>
+  * Fix invalid norwegian BBANS (failing MOD11 check) being incorrectly returned as valid

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -439,6 +439,12 @@ describe('IBANTools', function() {
     it('with valid BBAN and no country code should return false', function() {
       expect(iban.isValidBBAN('ABNA0417164300', null)).to.be.false;
     });
+    it('with invalid BBAN for country code NO should return false', function() {
+      expect(iban.isValidBBAN('12043175441', 'NO')).to.be.false;
+    })
+    it('with valid BBAN for country code NO should return true', function() {
+      expect(iban.isValidBBAN('12043175449', 'NO')).to.be.true;
+    })
   });
 
   describe('When calling composeIBAN()', function() {


### PR DESCRIPTION
We have a customer using this library who incorrectly verifies invalid BBANS failing the MOD11 check required on all norwegian BBANs. fixing this now so we wont have this issue with new customers using the same library to verify their BBANs

(for more info on norwegian BBANs: https://en.wikipedia.org/wiki/International_Bank_Account_Number#National_check_digits )