### PR TITLE
Add Mongolian (MN) specification

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2022-06-18	Zolboobayar Gantumur <zolboobayar@metainc.mn>
+	* Added Mongolian (MN) specification
+
 2022-03-10  Saša Jovanić <sasa@simplify.ba>
 	* Version 4.1.5
 

--- a/src/IBANTools.ts
+++ b/src/IBANTools.ts
@@ -1274,7 +1274,10 @@ export const countrySpecs: CountryMapInternal = {
     bban_regexp: '^[A-Z0-9]{2}[0-9]{22}$',
   },
   MM: {},
-  MN: {},
+  MN: {
+    chars: 20,
+    bban_regexp: '^[0-9]{16}$',
+  },
   MO: {},
   MP: {},
   MQ: {

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -281,6 +281,9 @@ describe('IBANTools', function() {
     it('with valid HU IBAN should return true', function() {
       expect(iban.isValidIBAN('HU90100320000160120200000000')).to.be.true;
     });
+    it('with valid MN IBAN should return true', function() {
+      expect(iban.isValidIBAN('MN121234123456789123')).to.be.true;
+    });
     it('with two dots should return false', function() {
       expect(iban.isValidIBAN('..')).to.be.false;
     });


### PR DESCRIPTION
Changes proposed in this pull request:
- Add Mongolian specification

Bank of Mongolia has approved [IBAN standard](https://www.mongolbank.mn/documents/regulation/paymentsystem/2020/20200313_%D0%9066.pdf) for bank account numbers on March 13, 2020. Transactions via IBAN have started on 1 Jan 2022 and it will become de-facto standard on 1 Jan 2024.

### Tests (check `[x]` one of those)

- [x] I have added test(s)
- [ ] My change does not need new tests

### ChangeLog

- [x] I have added entry in `ChangeLog` file (if not, please do so)
