### PR TITLE
Add country validation extension

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2022-10-26  Markus Baumer <markus@baumer.dev>
+  * New method `setCountryBBANValidation` for adding custom BBAN validations
+
 2022-03-10  Saša Jovanić <sasa@simplify.ba>
 	* Version 4.1.6
 	* Fix incorrectly setting BIC branch code to 619 instead of null #133

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ If you are using tools that support `jsnext`, like a [rollup](https://github.com
 
 Install library/module using npm. Package bundles type definitions and if you are on TypeScript 2.0 or above `tsc` will access those automatically. If not, check your `tsconfig.json` file.
 
+### Extension
+
+Country specifications can be extended with national BBAN validations by calling `setCountryBBANValidation`.
+
+For example, to fully syntactically check German IBAN, you can install [IBANTools-Germany](https://github.com/baumerdev/ibantools-germany) and add this with
+
+```
+const ibantools = require('ibantools');
+const ibantoolsGermany = require("ibantools-germany");
+ibantools.setCountryBBANValidation("DE", ibantoolsGermany.isValidBBAN);
+```
+
 ## Contributing
 
 This project adheres to the Contributor Covenant [code of conduct](https://github.com/Simplify/ibantools/blob/master/.github/CODE_OF_CONDUCT.md).

--- a/src/IBANTools.ts
+++ b/src/IBANTools.ts
@@ -848,6 +848,21 @@ const checkHungarianBBAN = (bban: string): boolean => {
 };
 
 /**
+ * Set custom BBAN validation function for country.
+ *
+ * If `bban_validation_func` already exists for the corresponding country,
+ * it will be overwritten.
+ */
+export const setCountryBBANValidation = (country: string, func: (bban: string) => boolean): boolean => {
+  if (typeof countrySpecs[country] === 'undefined') {
+    return false;
+  }
+
+  countrySpecs[country].bban_validation_func = func;
+  return true;
+};
+
+/**
  * Country specifications
  */
 export const countrySpecs: CountryMapInternal = {

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -739,4 +739,22 @@ describe('IBANTools', function() {
       expect(ext.NO.bban_validation_function).not.to.be.null;
     });
   });
+
+  describe('Adding custom BBAN validation function', function () {
+    it('with valid DE IBAN should return true', function () {
+      iban.setCountryBBANValidation('DE', () => false);
+
+      // This IBAN has been tested valid (see above).
+      // After we changed the method, it should now be false
+      expect(iban.isValidIBAN('DE89370400440532013000')).to.be.false;
+    });
+    it('Unknown country returns false', function () {
+      expect(iban.setCountryBBANValidation('XY', () => true)).to.be.false;
+    });
+    it('Unknown country cannot be modified', function () {
+      iban.setCountryBBANValidation('XY', () => true);
+      const ext = iban.getCountrySpecifications();
+      expect(ext.XY).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
Fixes #117

Changes proposed in this pull request:
- Add extension for custom BBAN validation functions

### Tests (check `[x]` one of those)

- [X] I have added test(s)
- [ ] My change does not need new tests

### ChangeLog

- [X] I have added entry in `ChangeLog` file (if not, please do so)
