### PR TITLE
Add SEPA attribute to true for VA (Vatican)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-07-11  Saša Jovanić <sasa@simplify.ba>
+	* Version 4.3.4
+	* Add SEPA attribute to VA (Vatican)
+
 2023-05-23  Saša Jovanić <sasa@simplify.ba>
 	* Version 4.3.3
 	* Remove outdated BBAN check for Finland

--- a/dist/ibantools.js
+++ b/dist/ibantools.js
@@ -1438,7 +1438,7 @@ define(["require", "exports"], function (require, exports) {
         US: {},
         UY: {},
         UZ: {},
-        VA: { chars: 22, bban_regexp: '^[0-9]{18}', IBANRegistry: true },
+        VA: { chars: 22, bban_regexp: '^[0-9]{18}', IBANRegistry: true, SEPA: true },
         VC: {},
         VE: {},
         VG: {

--- a/src/ibantools.ts
+++ b/src/ibantools.ts
@@ -1550,7 +1550,7 @@ export const countrySpecs: CountryMapInternal = {
   US: {},
   UY: {},
   UZ: {},
-  VA: { chars: 22, bban_regexp: '^[0-9]{18}', IBANRegistry: true },
+  VA: { chars: 22, bban_regexp: '^[0-9]{18}', IBANRegistry: true, SEPA: true },
   VC: {},
   VE: {},
   VG: {


### PR DESCRIPTION
Fixes #number-of-issue-this-pr-fixes-or-remove-this-line

Changes proposed in this pull request:
- Add SEPA attribute to VA (Vatican) as it is in SEPA.

### Tests (check `[x]` one of those)

- [ ] I have added test(s)
- [x] My change does not need new tests

### ChangeLog

- [x] I have added entry in `ChangeLog` file (if not, please do so)
