### PR TITLE
Fix typo in doc comment

### DIFF
--- a/src/ibantools.ts
+++ b/src/ibantools.ts
@@ -525,7 +525,7 @@ export interface ExtractBICResult {
 /**
  * extractBIC
  * ```
- * // returns {bankCode: "ABNA", countryCode: "NL", locationCode: "2A", branchCode: null, testBIC: flase, valid: true}
+ * // returns {bankCode: "ABNA", countryCode: "NL", locationCode: "2A", branchCode: null, testBIC: false, valid: true}
  * ibantools.extractBIC("ABNANL2A");
  * ```
  */


### PR DESCRIPTION
Fixed small typo in doc comment.
`flase` => `false`

### Tests (check `[x]` one of those)

- [ ] I have added test(s)
- [X] My change does not need new tests

### ChangeLog

- Not sure, if this request justifies a ChangeLog update.
