### PR TITLE
Remove Dutch BBAN check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-01-09  Saša Jovanić <sasa@simplify.ba>
+	* Version 4.3.9
+	* Removed Dutch (NL) BBAN validation
+
 2023-12-08  Saša Jovanić <sasa@simplify.ba>
 	* Version 4.3.8
 

--- a/dist/ibantools.js
+++ b/dist/ibantools.js
@@ -9,7 +9,7 @@ define(["require", "exports"], function (require, exports) {
      * @package Documentation
      * @author Saša Jovanić
      * @module ibantools
-     * @version 4.3.8
+     * @version 4.3.9
      * @license MPL-2.0
      * @preferred
      */
@@ -778,36 +778,6 @@ define(["require", "exports"], function (require, exports) {
         }
     };
     /**
-     * Dutch (NL) BBAN check
-     *
-     * @ignore
-     */
-    var checkDutchBBAN = function (bban) {
-        if (bban === '') {
-            return false;
-        }
-        var weights = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-        var toCheckAccount = bban.substring(4, 14);
-        if (toCheckAccount.startsWith('000')) {
-            return true;
-        }
-        if (toCheckAccount.startsWith('00')) {
-            return false;
-        }
-        var sum = toCheckAccount
-            .split('')
-            .map(function (value, index) {
-            if (value === '0' && index === 0) {
-                return 0;
-            }
-            var number = parseInt(value, 10);
-            var weight = weights[index];
-            return number * weight;
-        })
-            .reduce(function (a, b) { return a + b; });
-        return sum % 11 === 0;
-    };
-    /**
      * Set custom BBAN validation function for country.
      *
      * If `bban_validation_func` already exists for the corresponding country,
@@ -1460,7 +1430,6 @@ define(["require", "exports"], function (require, exports) {
         NL: {
             chars: 18,
             bban_regexp: '^[A-Z]{4}[0-9]{10}$',
-            bban_validation_func: checkDutchBBAN,
             IBANRegistry: true,
             SEPA: true,
             bank_identifier: '0-3',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibantools",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Validation, extraction and creation of IBAN, BBAN, BIC/SWIFT numbers plus some other helpful stuff like ISO 3136-1 alpha 2 country list",
   "keywords": [
     "IBAN",

--- a/src/ibantools.ts
+++ b/src/ibantools.ts
@@ -9,7 +9,7 @@
  * @package Documentation
  * @author Saša Jovanić
  * @module ibantools
- * @version 4.3.8
+ * @version 4.3.9
  * @license MPL-2.0
  * @preferred
  */
@@ -895,31 +895,6 @@ const checkHungarianBBAN = (bban: string): boolean => {
 };
 
 /**
- * Dutch (NL) BBAN check
- *
- * @ignore
- */
-const checkDutchBBAN = (bban: string): boolean => {
-  if(bban === '') { return false; }
-
-  const weights = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
-  const toCheckAccount = bban.substring(4, 14);
-  if(toCheckAccount.startsWith('000')) { return true; }
-  if(toCheckAccount.startsWith('00')) { return false; }
-  const sum: number = toCheckAccount
-    .split('')
-    .map((value: string, index: number) => {
-      if(value === '0' && index === 0) { return 0; }
-      const number = parseInt(value, 10);
-      const weight = weights[index];
-      return number * weight;
-    })
-    .reduce((a: number, b: number) => a + b);
-
-  return sum % 11 === 0;
-}
-
-/**
  * Set custom BBAN validation function for country.
  *
  * If `bban_validation_func` already exists for the corresponding country,
@@ -1573,7 +1548,6 @@ export const countrySpecs: CountryMapInternal = {
   NL: {
     chars: 18,
     bban_regexp: '^[A-Z]{4}[0-9]{10}$',
-    bban_validation_func: checkDutchBBAN,
     IBANRegistry: true,
     SEPA: true,
     bank_identifier: '0-3',

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -350,7 +350,6 @@ describe('IBANTools', function() {
         errorCodes: [
           iban.ValidationErrorsIBAN.WrongBBANLength,
           iban.ValidationErrorsIBAN.WrongBBANFormat,
-          iban.ValidationErrorsIBAN.WrongAccountBankBranchChecksum,
           iban.ValidationErrorsIBAN.WrongIBANChecksum,
         ],
       });
@@ -390,8 +389,7 @@ describe('IBANTools', function() {
     it('with invalid IBAN checksum should return false with correct code', function() {
       expect(iban.validateIBAN('NL91ABNA0517164300')).to.deep.equal({
         valid: false,
-        errorCodes: [iban.ValidationErrorsIBAN.WrongAccountBankBranchChecksum,
-		     iban.ValidationErrorsIBAN.WrongIBANChecksum],
+        errorCodes: [iban.ValidationErrorsIBAN.WrongIBANChecksum],
       });
     });
 
@@ -408,7 +406,6 @@ describe('IBANTools', function() {
         errorCodes: [
           iban.ValidationErrorsIBAN.WrongBBANLength,
           iban.ValidationErrorsIBAN.WrongBBANFormat,
-	  iban.ValidationErrorsIBAN.WrongAccountBankBranchChecksum,
           iban.ValidationErrorsIBAN.ChecksumNotNumber,
           iban.ValidationErrorsIBAN.WrongIBANChecksum,
         ],
@@ -697,7 +694,7 @@ describe('IBANTools', function() {
     it('branchIdentifier should be 00001', function() {
       expect(ext.branchIdentifier).to.equal('00001');
     });
-   });
+  });
 
   describe('When calling extractIBAN() with valid Slovenian IBAN', function() {
     var ext = iban.extractIBAN('SI56263300012039086');
@@ -722,7 +719,7 @@ describe('IBANTools', function() {
     it('branchIdentifier should be 330', function() {
       expect(ext.branchIdentifier).to.equal('330');
     });
-   });
+  });
 
   describe('When calling extractIBAN() with invalid IBAN', function() {
     var ext = iban.extractIBAN('BR970036030510009795493P1');
@@ -760,7 +757,6 @@ describe('IBANTools', function() {
     it('accountNumber should be 0417164300', function() {
       expect(ext.accountNumber).to.equal('0417164300');
     });
-
   });
 
   describe('When calling extractIBAN() with dash separated IBAN', function() {


### PR DESCRIPTION
Fixes and closes #487 and #415

Changes proposed in this pull request:
- Remove Dutch BBAN check. It's no longer required for Dutch bank accounts to be elf-proof as IBAN is used for all payments and IBAN itself has checksum.

### Tests (check `[x]` one of those)

- [ ] I have added test(s)
- [x] My change does not need new tests

### ChangeLog

- [x] I have added entry in `ChangeLog` file (if not, please do so)
