### PR TITLE
Fix ESM package entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,16 @@
   "sideEffects": false,
   "homepage": "https://github.com/Simplify/ibantools",
   "bugs": "https://github.com/Simplify/ibantools/issues",
-  "main": "build/ibantools.js",
+  "main": "build/ibantools.cjs",
   "type": "module",
   "module": "jsnext/ibantools.js",
+  "exports": {
+    ".": {
+      "types": "./build/ibantools.d.ts",
+      "import": "./jsnext/ibantools.js",
+      "require": "./build/ibantools.cjs"
+    }
+  },
   "jspm": {
     "main": "jsnext/ibantools.js",
     "format": "esm"
@@ -39,7 +46,7 @@
   },
   "scripts": {
     "build": "npm run build-node && npm run build-bower && npm run build-module",
-    "build-node": "rm -rf build && npx tsc --declaration --target es2017 --module commonjs --outDir ./build/",
+    "build-node": "rm -rf build && npx tsc --declaration --target es2017 --module commonjs --outDir ./build/ && cp ./build/ibantools.js ./build/ibantools.cjs",
     "build-bower": "rm -rf dist && npx tsc --declaration --target es2017 --module amd --outDir ./dist/",
     "build-module": "rm -rf jsnext && npx tsc --target es2017 --module es2020 --outDir ./jsnext/",
     "test": "npm run build && mocha 'test/**/*.js'",

--- a/test/package_entrypoints_test.js
+++ b/test/package_entrypoints_test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import { expect } from 'chai';
+import { createRequire } from 'node:module';
+import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
+
+describe('IBANTools package entrypoints', function() {
+  it('resolves named ESM exports from package root', function() {
+    expect(electronicFormatIBAN('nl91 abna 0417 1643 00')).to.equal('NL91ABNA0417164300');
+    expect(isValidIBAN('NL91ABNA0417164300')).to.equal(true);
+  });
+
+  it('keeps CommonJS require working from package root', function() {
+    const cjs = createRequire(import.meta.url)('ibantools');
+
+    expect(cjs.electronicFormatIBAN('nl91-abna-0417-1643-00')).to.equal('NL91ABNA0417164300');
+    expect(cjs.isValidIBAN('NL91ABNA0417164300')).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- route package-root `import` to the existing ESM build and `require` to an explicit CommonJS entry via an `exports` map
- point `main` to `build/ibantools.cjs` and generate that file during the node build so `type: module` no longer breaks CJS resolution
- add a package-root regression test covering both named ESM imports and CommonJS `require('ibantools')`

## Verification
- npm test
- npm run lint

Closes #672