### PR TITLE
Report coverage only on one file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "build-bower": "rm -rf dist && npx tsc --declaration --target es2017 --module amd --outDir ./dist/",
     "build-module": "rm -rf jsnext && npx tsc --target es2017 --module es2020 --outDir ./jsnext/",
     "test": "npm run build && mocha 'test/**/*.js'",
-    "coverage": "npm run build && c8 mocha && c8 report --reporter=text-lcov > test.lcov",
+    "coverage": "npm run build && c8 mocha && c8 report -e \".js\" --reporter=text-lcov > test.lcov",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.js'",
     "prepare": "npm run build-node",
     "docs": "typedoc src/ibantools.ts",


### PR DESCRIPTION
Changes proposed in this pull request:
- Measure test coverage only on js file and ignore cjs

### Tests (check `[x]` one of those)

- [ ] I have added test(s)
- [x] My change does not need new tests

### ChangeLog

- [ ] I have added entry in `ChangeLog` file (if not, please do so)
