### PR TITLE
fix(BY): allow digits in the Belarus bank identifier (4!c)

### DIFF
--- a/src/ibantools.ts
+++ b/src/ibantools.ts
@@ -1038,7 +1038,7 @@ export const countrySpecs: CountryMapInternal = {
   BW: {},
   BY: {
     chars: 28,
-    bban_regexp: '^[A-Z]{4}[0-9]{4}[A-Z0-9]{16}$',
+    bban_regexp: '^[A-Z0-9]{4}[0-9]{4}[A-Z0-9]{16}$',
     IBANRegistry: true,
     bank_identifier: '0-3',
   },

--- a/test/ibantools_test.js
+++ b/test/ibantools_test.js
@@ -33,6 +33,9 @@ describe('IBANTools', function() {
     it('with valid BY IBAN should return true', function() {
       return expect(iban.isValidIBAN('BY13NBRB3600900000002Z00AB00')).to.be.true;
     });
+    it('with valid BY IBAN whose bank code contains a digit should return true', function() {
+      return expect(iban.isValidIBAN('BY26AKB10100000002966000000A')).to.be.true;
+    });
     it('with valid CR IBAN should return true', function() {
       return expect(iban.isValidIBAN('CR25010200009074883572')).to.be.true;
     });


### PR DESCRIPTION
### Problem

The Belarus BBAN structure is `4!c4!n16!c` per the ISO 13616 / SWIFT IBAN Registry, where the leading 4-character **bank identifier** is `4!c` — alphanumeric (digits *or* uppercase letters). The current spec encodes it as `[A-Z]{4}` (letters only):

```
BY: { chars: 28, bban_regexp: '^[A-Z]{4}[0-9]{4}[A-Z0-9]{16}$', ... }
```

As a result, an otherwise-valid Belarus IBAN whose bank code contains a digit is rejected:

```js
const { isValidIBAN } = require('ibantools');

isValidIBAN('BY13NBRB3600900000002Z00AB00');   // true  (bank code = letters)
isValidIBAN('BY26AKB10100000002966000000A');   // false (bank code "AKB1" — BUG)
```

`BY26AKB10100000002966000000A` is well-formed: 28 characters, BBAN `4!c4!n16!c`, and its mod-97 check digits are valid (remainder 1). The only reason it fails is the bank field rejecting the digit `1`.

### Fix

Change the bank field from `[A-Z]{4}` to `[A-Z0-9]{4}`. The neighbouring branch field `[0-9]{4}` (`4!n`) and account field `[A-Z0-9]{16}` (`16!c`) are already correct, so this aligns the bank field with the same registry, consistent with prior BBAN-format corrections in this project.

### References

- SWIFT IBAN Registry (ISO 13616): Belarus BBAN `4!c4!n16!c`, length 28.

### Test

Added an assertion that a Belarus IBAN with a digit in the bank code validates. It fails before the change and passes after; the full suite is green.